### PR TITLE
Remove not neeted port mapping in docker-compose

### DIFF
--- a/docs/Installation/installation-docker.md
+++ b/docs/Installation/installation-docker.md
@@ -33,9 +33,7 @@ services:
     restart: unless-stopped
     image: vallezw/sheetable
     ports:
-      - 8080:3006
-    environment:
-      - PORT:3006
+      - 80:8080
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /local/path/config/dir:/app/config


### PR DESCRIPTION
As far as I understand the code, the default port is 8080. There is no need to set the internal port to something else using the environment variables and it might confuses the user. It's only important under which port the app is available from outside of the docker container.

Sorry, for opening so many pull requests recently. But I hope it helps. :) I'm very excited about this project.