### PR TITLE
Amended custom port and config path environment variables

### DIFF
--- a/docs/Installation/installation-docker.md
+++ b/docs/Installation/installation-docker.md
@@ -35,7 +35,8 @@ services:
     ports:
       - 8080:3006
     environment:
-      - PORT:3006
+      - PORT=3006
+      - CONFIG_PATH=/app/config/
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /local/path/config/dir:/app/config


### PR DESCRIPTION
Added `CONFIG_PATH` and changed syntax for `PORT=3006` in example docker-compose.yml, as the previous syntax (`PORT:3306`) had no effect.